### PR TITLE
Add code style guidelines link to main README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ for working and collaborating in the lab.
 * Software development platform -- New to Git and GitHub?  Have a look at
   the [introductory guide for Git and GitHub](git-github-introduction.md),
   which is our lab's recommended software development platform.
+* Please follow the
+[lab's coding guidelines](https://github.com/secure-systems-lab/code-style-guidelines).
 * Writing LaTeX documents -- Clear communication is key at SSL, and
   our [LaTeX guide](latexdocuments.md) helps you master an academic
   researcher's number 1 document preparation system.


### PR DESCRIPTION
Does just that (;

While the code style guidelines was linked to from the [SSL website landing page](https://ssl.engineering.nyu.edu/collaborate), it wasn't in the overview README for this repo.