### PR TITLE
Advise PR submitters to look through CI test results

### DIFF
--- a/dev-workflow.md
+++ b/dev-workflow.md
@@ -59,6 +59,8 @@ Travis-CI and AppVeyor) and report the results in the pull request page itself.
 This helps identify possible problems in pull requests, or point to indicate
 where test code needs to be modified due to the changes.  If builds fail for
 your pull request, look through the output and see if you can fix the problems.
+You can also run tests locally!  Check the `.travis.yml` or `appveyor.yml` files
+to see what commands the build systems run.
 
 1. **Request a review**. You can request reviews directly in *GitHub*. Also,
 don't be afraid to re-ask if no one has been on it after a couple of days.

--- a/dev-workflow.md
+++ b/dev-workflow.md
@@ -53,5 +53,12 @@ for further instructions. And beware of the following pitfalls:
     to really understand what the PR is about. This is really important for
     reviewers!
 
+1. **Review tests**.  After submitting a pull request to most lab projects,
+continuous integration (CI) should run automated test builds (commonly via
+Travis-CI and AppVeyor) and report the results in the pull request page itself.
+This helps identify possible problems in pull requests, or point to indicate
+where test code needs to be modified due to the changes.  If builds fail for
+your pull request, look through the output and see if you can fix the problems.
+
 1. **Request a review**. You can request reviews directly in *GitHub*. Also,
 don't be afraid to re-ask if no one has been on it after a couple of days.


### PR DESCRIPTION
It's useful training and useful to the projects for student contributors who submit pull requests to lab projects to see where their PRs break testing.  This adds a bullet point to the development guidelines suggesting that.