### PR TITLE
Add code review guideline

### DIFF
--- a/code-review.md
+++ b/code-review.md
@@ -1,0 +1,64 @@
+# Code Review Guidelines
+
+Code reviews are important, both to ensure code quality, and to learn from each
+other. To get the most out of it, code authors should voice their expectations
+of a review, and reviewers should state the performed actions and areas of
+focus.
+
+The necessary prerequisite for a *line-by-line* review is that code authors
+make sure that the changes they propose actually make sense and work at a basic
+level. *Corollary: It should never happen that neither the author nor the
+reviewer actually tests the fix.* It is still okay to request feedback on work
+in progress, but especially then it is important to be explicit about the depth
+of the desired review.
+
+__As code author (pre-review):__
+
+1. Make sure your proposed change does what you think it should do. This also
+   means that it conforms to the [code
+   style](https://github.com/secure-systems-lab/code-style-guidelines) etc. *Do
+   not waste the reviewer's time with things you can easily get right in the
+   first place!*
+
+1. Send a PR, that follows our [PR
+   guideline](commits.md#pull-request-guidelines-wip), and describe what you
+   think are the aspects that require the largest share of a reviewer's
+   attention:
+   > "Please do / look for / look at the following: ...."
+
+1. Feel free to suggest the review to someone, e.g. by using [GitHub's *review
+   request*](https://help.github.com/en/articles/requesting-a-pull-request-review)
+   feature or by leaving a comment. Don't don't be afraid to remind them, if no
+   one has been on it after a couple of days.
+
+
+__As code reviewer:__
+
+1. Inform the world about your review intent, e.g. by using [GitHub's
+   *self-assign*](https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users)
+   feature, or by leaving a comment.
+
+1. [Perform the
+   review](https://help.github.com/en/articles/reviewing-proposed-changes-in-a-pull-request).
+   Be diligent, but also remember that the goal is not to demonstrate your
+   review skills but to integrate the proposed bug fix or feature. And be
+   respectful.
+
+1. Mention the areas (topical, regional) you focused on. Feel free to mention
+   areas you cannot review as well:
+   > "Here's what I did to review your code: ...."
+
+
+__As code author (post-review):__
+
+1. Address **all (!)** review comments. *Do not waste the reviewer's time by
+   having them leave the same comment twice!*
+
+    - Reply to the comment, if it is unclear, or you think the reviewer got
+      something wrong.
+
+    - Push new commits that address the comment, otherwise. These commits
+      follow the same [guidelines as regular commits](commits.md). Also see
+      notes about [rebasing in an open *pull request*](git-history.md).
+
+1. Start over with *"As code author (pre-review)"* above...

--- a/code-review.md
+++ b/code-review.md
@@ -1,7 +1,7 @@
 # Code Review Guidelines
 
-Code reviews are important, both to ensure code quality, and to learn from each
-other. To get the most out of it, code authors should voice their expectations
+Code reviews are important, not only to ensure code quality, but also so project team members can learn from each
+other. To get the most out of the process, code authors should voice their expectations
 of a review, and reviewers should state the performed actions and areas of
 focus.
 
@@ -19,7 +19,7 @@ __As code author (pre-review):__
    pass, etc. *Do not waste the reviewer's time with things you can easily get
    right in the first place!*
 
-1. Send a PR, that follows our [PR
+1. Send a PR that follows our [PR
    guideline](commits.md#pull-request-guidelines-wip), and describe what you
    think are the aspects that require the largest share of a reviewer's
    attention:
@@ -30,8 +30,8 @@ __As code author (pre-review):__
    feature, or by leaving a comment on the *pull request* page, mentioning the
    desired
    [`@<reviewer>`](https://help.github.com/en/articles/basic-writing-and-formatting-syntax#mentioning-people-and-teams).
-   Don't be afraid to remind them, if no one has been on it after a couple of
-   days.
+   Don't be afraid to send a reminder after a couple of
+   days if no one has addressed your request.
 
 
 __As code reviewer:__
@@ -46,7 +46,7 @@ __As code reviewer:__
    e.g. if a docs PR adds URLs, check if they actually resolve, etc.
    Be diligent, but also remember that the goal is not to demonstrate your
    review skills but to integrate the proposed bug fix or feature. And be
-   respectful.
+   respectful in word choice and tone.
 
 1. Mention the areas (topical, regional) you focused on. Feel free to mention
    areas you cannot review as well:
@@ -56,9 +56,9 @@ __As code reviewer:__
 __As code author (post-review):__
 
 1. Address **all (!)** review comments. *Do not waste the reviewer's time by
-   having them leave the same comment twice!*
+   forcing them to leave the same comment twice!*
 
-    - Reply to the comment, if it is unclear, or you think the reviewer got
+    - Reply to the comment if it is unclear or you think the reviewer got
       something wrong.
 
     - Otherwise, push new commits that address the comment. These commits

--- a/code-review.md
+++ b/code-review.md
@@ -6,19 +6,18 @@ of a review, and reviewers should state the performed actions and areas of
 focus.
 
 The necessary prerequisite for a *line-by-line* review is that code authors
-make sure that the changes they propose actually make sense and work at a basic
-level. *Corollary: It should never happen that neither the author nor the
-reviewer actually tests the fix.* It is still okay to request feedback on work
-in progress, but especially then it is important to be explicit about the depth
-of the desired review.
+make sure that the changes they propose actually make sense and the unit and
+integration tests pass. *It is still okay to request feedback on work in
+progress, but especially then it is important to be explicit about the depth of
+the desired review.*
 
 __As code author (pre-review):__
 
 1. Make sure your proposed change does what you think it should do. This also
    means that it conforms to the [code
-   style](https://github.com/secure-systems-lab/code-style-guidelines) etc. *Do
-   not waste the reviewer's time with things you can easily get right in the
-   first place!*
+   style](https://github.com/secure-systems-lab/code-style-guidelines), tests
+   pass, etc. *Do not waste the reviewer's time with things you can easily get
+   right in the first place!*
 
 1. Send a PR, that follows our [PR
    guideline](commits.md#pull-request-guidelines-wip), and describe what you
@@ -26,20 +25,25 @@ __As code author (pre-review):__
    attention:
    > "Please do / look for / look at the following: ...."
 
-1. Feel free to suggest the review to someone, e.g. by using [GitHub's *review
+1. Suggest the review to someone, e.g. by using [GitHub's *review
    request*](https://help.github.com/en/articles/requesting-a-pull-request-review)
-   feature or by leaving a comment. Don't don't be afraid to remind them, if no
-   one has been on it after a couple of days.
+   feature, or by leaving a comment on the *pull request* page, mentioning the
+   desired
+   [`@<reviewer>`](https://help.github.com/en/articles/basic-writing-and-formatting-syntax#mentioning-people-and-teams).
+   Don't be afraid to remind them, if no one has been on it after a couple of
+   days.
 
 
 __As code reviewer:__
 
-1. Inform the world about your review intent, e.g. by using [GitHub's
+1. State your intent, e.g. by using [GitHub's
    *self-assign*](https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users)
-   feature, or by leaving a comment.
+   feature, or by leaving a comment on the *pull request* page.
 
 1. [Perform the
    review](https://help.github.com/en/articles/reviewing-proposed-changes-in-a-pull-request).
+   Try to catch mistakes that might have slipped through automated testing,
+   e.g. if a docs PR adds URLs, check if they actually resolve, etc.
    Be diligent, but also remember that the goal is not to demonstrate your
    review skills but to integrate the proposed bug fix or feature. And be
    respectful.
@@ -57,7 +61,7 @@ __As code author (post-review):__
     - Reply to the comment, if it is unclear, or you think the reviewer got
       something wrong.
 
-    - Push new commits that address the comment, otherwise. These commits
+    - Otherwise, push new commits that address the comment. These commits
       follow the same [guidelines as regular commits](commits.md). Also see
       notes about [rebasing in an open *pull request*](git-history.md).
 

--- a/dev-workflow.md
+++ b/dev-workflow.md
@@ -63,5 +63,5 @@ your pull request, look through the output and see if you can fix the problems.
 You can also run tests locally!  Check the `.travis.yml` or `appveyor.yml` files
 to see what commands the build systems run.
 
-1. **Request a review**. You can request reviews directly in *GitHub*. Also,
-don't be afraid to re-ask if no one has been on it after a couple of days.
+1. **Request a code review**. See our [code review guidelines](code-review.md)
+   for more details.


### PR DESCRIPTION
Add guideline document about code reviews that may be used in addition to the development guideline document by code authors and code reviewers.

This document is largely based on a proposal by @aaaaalbert (see #17). It aims at making his proposal more succinct and adds post-review code author guidelines. Thanks, Albert!

I suggest @jhdalek55 and/or @JustinCappos as reviewers. Please review for conciseness and unnecessary redundancy with our [development guidelines](https://github.com/secure-systems-lab/lab-guidelines/blob/master/dev-workflow.md). Feel free to edit on this branch.
